### PR TITLE
Update tAdios2StMan.cc

### DIFF
--- a/tables/DataMan/test/tAdios2StMan.cc
+++ b/tables/DataMan/test/tAdios2StMan.cc
@@ -279,7 +279,7 @@ void doReadCopiedTable(std::string filename, std::string column, uInt rows, IPos
     VerifyArrayColumn<Complex>(tab, column, rows, array_pos);
 }
 
-int main() {
+int main(int argc, char **argv) {
 
 #ifdef HAVE_MPI
     MPI_Init(&argc,&argv);


### PR DESCRIPTION
MPI_Init had the following argc, argv arguments which were not defined on main(), causing compilation issues.